### PR TITLE
Fixed call for event to handle additional incoming args

### DIFF
--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -43,7 +43,7 @@ def fzf_insert(items, current_buffer, prefix='', suffix=''):
 
 
 @events.on_ptk_create
-def custom_keybindings(bindings, **kw):
+def custom_keybindings(shortcut, history, completer, bindings, **kw):
     def handler(key_name):
         def do_nothing(func):
             pass


### PR DESCRIPTION
It looks like in the newer versions of Xonsh (or prompt_toolkit) they are passing more arguments. This handles the additional arguments passed in so that it will load up.