### PR TITLE
Adjusting to prompt_toolkit 2.x syntax

### DIFF
--- a/xontrib/fzf-widgets.xsh
+++ b/xontrib/fzf-widgets.xsh
@@ -50,7 +50,7 @@ def custom_keybindings(shortcut, history, completer, bindings, **kw):
 
         key = ${...}.get(key_name)
         if key:
-            return bindings.registry.add_binding(key)
+            return bindings.add(key)
         return do_nothing
 
     @handler('fzf_history_binding')


### PR DESCRIPTION
prompt_toolkit 2.x syntax is slightly different, see https://xon.sh/tutorial_ptk.html

Fixed #9 